### PR TITLE
Adds the a filter setting to only load Sentry JS on certain pages.

### DIFF
--- a/templates/_settings.twig
+++ b/templates/_settings.twig
@@ -29,6 +29,15 @@
     errors:       settings.getErrors('reportJsErrors')
 }) }}
 
+{{ forms.textField({
+    label:        "Javascript Error Reporting Page Filter"|t,
+    instructions: "If javascript error reporting is enabled, this will act as a case-insensitive filter to only load the JS
+    reporting (raven-js) on pages that match this expression. If the filter is a valid perl-style regular expression then it will be used as such."|t,
+    id:           'jsRegexFilter',
+    name:         'jsRegexFilter',
+    value:        settings.jsRegexFilter,
+    errors:       settings.getErrors('jsRegexFilter')
+}) }}
 
 {{ forms.lightswitchField({
 	label:        "Report in devMode?"|t,


### PR DESCRIPTION
This PR adds an option to filter which pages get the sentry JS included when the sentry JS option is enabled.

The reason we needed to do this is because we have a lot of volume coming to our site and some of our pages include lots of remote JS and we don't want to report JS errors from those pages as a result. Otherwise our sentry dashboard has way too many errors we don't care about.

![](http://monosnap.com/image/WBQeJBbeR3nAL16dpk7uW0ccAohHAo.png)

Thanks!
