### PR TITLE
Added new config option to let you ignore certain error codes from being sent to Sentry

### DIFF
--- a/templates/_settings.twig
+++ b/templates/_settings.twig
@@ -47,3 +47,12 @@
 	on:           settings.reportInDevMode,
 	errors:       settings.getErrors('reportInDevMode')
 }) }}
+
+{{ forms.textField({
+    label:        "Ignore These HTTP Error Codes"|t,
+    instructions: "Enter a comma separated list of HTTP error codes that should NOT be sent to sentry if encountered (default: report all errors)"|t,
+    id:           'ignoredErrorCodes',
+    name:         'ignoredErrorCodes',
+    value:        settings.ignoredErrorCodes,
+    errors:       settings.getErrors('ignoredErrorCodes')
+}) }}


### PR DESCRIPTION
# What?

Added new config option to let you ignore certain error codes from being sent to Sentry

![](http://monosnap.com/image/bpTMUne2sRqvzTlED9OH22nJY7vKgB.png)
# Why?

We get FLOODED with 403, 404, etc errors coming from bots scanning our website that gets a massive amount of traffic. We use Google Analytics and Google Webmaster Tools to track 404s and 4-level errors, so this is not needed.
# How?

It checks to see if the HttpException statusCode attribute value is in the ignored list. If so, it is not sent to Sentry with Raven. 
