### PR TITLE
Added ability for sentry config to be loaded from environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,24 @@ Sentry plugin for Craft CMS
 =================
 
 Plugin that allows you to log Craft Errors/Exceptions to Sentry, based on [https://github.com/boboldehampsink/rollbar](https://github.com/boboldehampsink/rollbar)
+
+![Craft Sentry plugin admin settings screen screenshot](http://monosnap.com/image/nvFCfnMenK6DhMDd669klEDlxn7Tks.png)
  
 Features
 =================
  - Log Craft Errors/Exceptions to Sentry
- - Enter Sentry DSN via Plugin settings
  - Logs the environment you're working on
  - Integrates seamlessly, one click install
+ - You can limit what pages get JS Raven loaded on them by applying a page filter.
+ - You can limit which HTTP error codes get reported to sentry in the settings (for example, if you don't want to report 400 or 404 errors).
+
+Setup
+=================
+Two ways to configure the plugin:
+
+* Enter Sentry DSN or public DSN (for JS reporting) via Plugin settings \
+**or** 
+* Via your server's environment (loaded `$_ENV['sentryDsn']` and `$_ENV['sentryPublicDsn']`)
  
 Important:
 =================
@@ -16,6 +27,9 @@ The plugin's folder should be named "sentry"
 
 Changelog
 =================
-
-###1.0###
+### 1.1.1
+- Added ability to load DSN/publicDSN from .env
+### 1.1
+- Added ability to ignore HTTP error codes, JS error reporting, JS error page filters, etc.
+### 1.0
  - Initial push to GitHub after changes from https://github.com/boboldehampsink/rollbar

--- a/SentryPlugin.php
+++ b/SentryPlugin.php
@@ -35,7 +35,7 @@ class SentryPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.1.0';
+        return '1.1.1';
     }
 
     /**
@@ -126,7 +126,7 @@ class SentryPlugin extends BasePlugin
         require_once CRAFT_PLUGINS_PATH.'sentry/vendor/autoload.php';
 
         // Initialize Sentry
-        $client = new Raven_Client($settings->dsn);
+        $client = new Raven_Client(craft()->sentry->dsn);
         $client->tags_context(array('environment' => CRAFT_ENVIRONMENT));
 
         $this->attachRavenErrorHandlers($client);
@@ -198,7 +198,7 @@ class SentryPlugin extends BasePlugin
 
         craft()->templates->includeJsFile('https://cdn.ravenjs.com/1.1.22/jquery,native/raven.min.js');
 
-        $publicDsn = $settings->publicDsn;
+        $publicDsn = craft()->sentry->publicDsn;
         if (empty($publicDsn)) {
             return $this;
         }

--- a/config.php
+++ b/config.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+    'sentryDsn' => !empty($_ENV['SENTRY_DSN']) ? $_ENV['SENTRY_DSN'] : '',
+    'sentryPublicDsn' => !empty($_ENV['SENTRY_PUBLIC_DSN']) ? $_ENV['SENTRY_PUBLIC_DSN'] : '',
+);

--- a/templates/_settings.twig
+++ b/templates/_settings.twig
@@ -1,24 +1,38 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
-    first:        true,
-    label:        "DSN"|t,
-    id:           'dsn',
-    name:         'dsn',
-    instructions: "Sentry project DSN (aka Client Key)."|t,
-    value:        settings.dsn,
-    autofocus:    true,
-    errors:       settings.getErrors('dsn')
-}) }}
+<style> .sentry-settings-notice { font-style: italic; margin-bottom: 12px; } </style>
 
-{{ forms.textField({
-    label:        "Public DSN"|t,
-    id:           'publicDsn',
-    name:         'publicDsn',
-    instructions: "You need a public DSN if you plan on reporting client-side javascript errors. You can get your public DSN by logging-into Sentry and going to th integrations page."|t,
-    value:        settings.publicDsn,
-    errors:       settings.getErrors('publicDsn')
-}) }}
+{% if craft.sentry.isDsnSpecifiedByEnv %}
+    <div class="sentry-settings-notice">
+        {{ "Your DSN is specified by your environment. Please ask your server administrator to configure the value if you need to change it."|t}}
+    </div>
+{% else %}
+    {{ forms.textField({
+        first:        true,
+        label:        "DSN"|t,
+        id:           'dsn',
+        name:         'dsn',
+        instructions: "Sentry project DSN (aka Client Key). NOTE: This is overriden by your environment's SENTRY_DSN value if it is specified."|t,
+        value:        settings.dsn,
+        autofocus:    true,
+        errors:       settings.getErrors('dsn')
+    }) }}
+{% endif %}
+
+{% if craft.sentry.isPublicDsnSpecifiedByEnv %}
+    <div class="sentry-settings-notice">
+        {{ "Your public DSN is specified by your environment. Please ask your server administrator to configure the value if you need to change it."|t}}
+    </div>
+{% else %}
+    {{ forms.textField({
+        label:        "Public DSN"|t,
+        id:           'publicDsn',
+        name:         'publicDsn',
+        instructions: "You need a public DSN if you plan on reporting client-side javascript errors. You can get your public DSN by logging-into Sentry and going to th integrations page. NOTE: This is overriden by your environment's SENTRY_PUBLIC_DSN value if it is specified."|t,
+        value:        settings.publicDsn,
+        errors:       settings.getErrors('publicDsn')
+    }) }}
+{% endif %}
 
 {{ forms.lightswitchField({
     label:        "Enable Javascript Error Reporting?"|t,

--- a/variables/SentryVariable.php
+++ b/variables/SentryVariable.php
@@ -40,7 +40,41 @@ class SentryVariable
      */
     public function dsn()
     {
+        if ($dsn = craft()->config->get('sentryDsn', 'sentry')) {
+            return $dsn;
+        }
         return $this->_settings->getAttribute('dsn');
+    }
+
+    /**
+     * True if the Sentry DSN is specified by the environment (.env or whatever)
+     * @return boolean
+     */
+    public function isDsnSpecifiedByEnv()
+    {
+        return craft()->config->get('sentryDsn', 'sentry') ? true : false;
+    }
+
+    /**
+     * Returns Sentry public DSN.
+     *
+     * @return string
+     */
+    public function publicDsn()
+    {
+        if ($publicDsn = craft()->config->get('sentryPublicDsn', 'sentry')) {
+            return $publicDsn;
+        }
+        return $this->_settings->getAttribute('publicDsn');
+    }
+    
+    /**
+     * True if the Sentry public DSN is specified by the environment (.env or whatever)
+     * @return boolean
+     */
+    public function isPublicDsnSpecifiedByEnv()
+    {
+        return craft()->config->get('sentryPublicDsn', 'sentry') ? true : false;
     }
 
     /**
@@ -52,4 +86,5 @@ class SentryVariable
     {
         return $this->_settings->getAttribute('reportInDevMode');
     }
+
 }


### PR DESCRIPTION
@adamdburton 
## What?

I added the ability for the module to read the DSN settings from the .env. 
## What?

Two reasons
1. We are constantly taking production dumps to work with live entry data, we keep accidentally taking down the sentry keys and developers are accidentally reporting errors to the live Sentry instance.
2. Giving admins the ability to take down our enter website by messing up the config website is a huge security risk for larger businesses. Storing in the

Storing in the .env solves both these issues.
## Demo

You can see here I'm setting my .env values and the settings are immediately recognized.
![](http://g.recordit.co/iGJNgRR8DY.gif)

**Note:** Setting the environment values override config values if they are set (if empty, config values are used).

Thanks!
