### PR TITLE
Add JS Exclusion filter setting

### DIFF
--- a/templates/_settings.twig
+++ b/templates/_settings.twig
@@ -44,13 +44,23 @@
 }) }}
 
 {{ forms.textField({
-    label:        "Javascript Error Reporting Page Filter"|t,
+    label:        "Javascript Error Reporting Page Inclusion Filter"|t,
     instructions: "If javascript error reporting is enabled, this will act as a case-insensitive filter to only load the JS
     reporting (raven-js) on pages that match this expression. If the filter is a valid perl-style regular expression then it will be used as such."|t,
-    id:           'jsRegexFilter',
-    name:         'jsRegexFilter',
-    value:        settings.jsRegexFilter,
-    errors:       settings.getErrors('jsRegexFilter')
+    id:           'jsInclusionRegexFilter',
+    name:         'jsInclusionRegexFilter',
+    value:        settings.jsInclusionRegexFilter,
+    errors:       settings.getErrors('jsInclusionRegexFilter')
+}) }}
+
+{{ forms.textField({
+    label:        "Javascript Error Reporting Page Exclusion Filter"|t,
+    instructions: "If javascript error reporting is enabled, this will act as a case-insensitive filter to only exclue the JS
+    reporting (raven-js) from pages that match this expression. If the filter is a valid perl-style regular expression then it will be used as such."|t,
+    id:           'jsExclusionRegexFilter',
+    name:         'jsExclusionRegexFilter',
+    value:        settings.jsExclusionRegexFilter,
+    errors:       settings.getErrors('jsExclusionRegexFilter')
 }) }}
 
 {{ forms.lightswitchField({


### PR DESCRIPTION
Just an idea here:

We have encountered the need for an exclusion filter (not adding JS error tracking to specific pages slated to be imported into our email-newsletter-generator doodad). This is handy for us, but could probably use more thought around the best way to handle the settings.
